### PR TITLE
Update photoz_helper.py

### DIFF
--- a/astro_ghost/photoz_helper.py
+++ b/astro_ghost/photoz_helper.py
@@ -305,6 +305,8 @@ def get_common_constraints_columns():
 def preprocess(DF,PATH='../DATA/sfddata-master/', ebv=True):
     if ebv:
         m = sfdmap.SFDMap(PATH)
+        assert ('raMean' in DF.columns()) and ('decMean' in DF.columns()), 'DustMap query failed because the expected coordinates didnt'\
+                                                                            'exist in DF, likely the match of any Hosts into PanStarrs failed'
         EBV = m.ebv(DF['raMean'].values.astype(np.float32),DF['decMean'].values.astype(np.float32))
 
         DF['ebv'] = EBV


### PR DESCRIPTION
This adds an assertion statement to help clarify what I think would be a confusing error to a user. More generally... I think this is fixed by Kostoya's change since the user will be exposed to the DF I create as a result of the PanStarrs query, which will make the query results directly explorable. When that query fails completely for all Hosts, then this will fail appropriately.